### PR TITLE
feature: Change jQuery protocol to HTTPS in <script> tag and correct …

### DIFF
--- a/index.html
+++ b/index.html
@@ -82,9 +82,9 @@
 		</div>
 	</div>
 
-	<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
+	<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
 	<script defer src="https://use.fontawesome.com/releases/v5.0.6/js/all.js"></script>
-	<script type="module" src="./home/index.js"></script>
+	<script type="module" src="./src/home/index.js"></script>
 
 </body>
 


### PR DESCRIPTION
…index.js <script> URL

Correct the protocol for the jQuery <script src="..."> attribute to HTTPS to prevent the request from being blocked by Chrome. Fix the URL of the index.js <script> to eliminate the 404 error.

Resolves: N/a
See Also: https://github.com/jdmedlock/pixelartmaker/issues/2